### PR TITLE
Make vodsl.standalone compile again.

### DIFF
--- a/eclipse.target/eclipse.vodsl.target.target
+++ b/eclipse.target/eclipse.vodsl.target.target
@@ -23,18 +23,13 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="de.cau.cs.kieler.kiml.formats" version="0.2.4.201506231527"/>
 <unit id="de.cau.cs.kieler.core.kgraph" version="0.7.2.201506231527"/>
-<unit id="de.fxdiagram.sdk.feature.feature.group" version="0.35.1.201705101730"/>
-<unit id="org.eclipse.xtext.example.fowlerdsl.ui" version="2.8.4.201508041756"/>
+<unit id="de.fxdiagram.sdk.feature.feature.group" version="0.36.1.201709062056"/>
 <unit id="de.cau.cs.kieler.core" version="0.14.1.201506231527"/>
 <unit id="de.cau.cs.kieler.kiml.graphviz.dot" version="0.7.1.201612130921"/>
 <unit id="de.cau.cs.kieler.kiml.service" version="0.8.0.201506231527"/>
-<unit id="org.eclipse.xtext.example.domainmodel" version="2.8.4.201508041756"/>
 <unit id="de.cau.cs.kieler.kiml.graphviz.layouter" version="0.7.0.201506231527"/>
-<unit id="de.fxdiagram.sdk.feature.source.feature.group" version="0.35.1.201705101730"/>
-<unit id="org.eclipse.fx.ide.basic.feature.feature.group" version="2.4.0.201605112122"/>
-<unit id="de.fxdiagram.eclipse.examples.feature.feature.group" version="0.35.1.201705101730"/>
-<unit id="org.eclipse.xtext.example.domainmodel.ui" version="2.8.4.201508041756"/>
-<unit id="org.eclipse.xtext.example.fowlerdsl" version="2.8.4.201508041756"/>
+<unit id="de.fxdiagram.sdk.feature.source.feature.group" version="0.36.1.201709062056"/>
+<unit id="de.fxdiagram.eclipse.examples.feature.feature.group" version="0.36.1.201709062056"/>
 <unit id="de.cau.cs.kieler.kiml" version="0.18.0.201506231527"/>
 <repository location="http://dl.bintray.com/jankoehnlein/FXDiagram"/>
 </location>

--- a/net.ivoa.vodml/pom.xml
+++ b/net.ivoa.vodml/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                   <groupId>org.eclipse.emf</groupId>
                   <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-                  <version>2.9.0.201605261059</version>
+                  <version>2.9.1.201705291010</version>
                </dependency>
                <dependency>
                   <groupId>org.eclipse.xtext</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,20 +9,22 @@
    <properties>
       <tycho-version>1.2.0</tycho-version>
       <tycho-extras-version>1.2.0</tycho-extras-version>
-      <xtextVersion>2.14.0</xtextVersion>
+      <xtextVersion>2.16.0</xtextVersion>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.compiler.target>1.8</maven.compiler.target>
    </properties>
    <modules>
       <module>net.ivoa.vodml</module>
-      <module>net.ivoa.vodml.ui</module>
-      <module>net.ivoa.vodml.ide</module>
       <module>eclipse.target</module>
+      <module>vodsl.standalone</module>
+<!--
+      <module>net.ivoa.vodml.ide</module>
+      <module>net.ivoa.vodml.ui</module>
       <module>net.ivoa.vodml.sdk</module>
       <module>eclipse.repository</module>
-      <!-- <module>vodsl.standalone</module> -->
-      <!-- <module>javaparser</module> -->
+      <module>javaparser</module>
+-->
    </modules>
    <build>
       <plugins>


### PR DESCRIPTION
Upgraded fxdiagram to 0.35.1.201705101730.
Upgraded org.eclipse.emf.mwe2.launch to 2.9.1.201705291010
Upgraded xtextVersion to 2.16.0
Removed xtext.example dependencies.

Eclipse plugin does not yet compile. So do not merge as-is.

Also, I can only use `mvn install` once, because it will hardcode the xtext version to 2.14.0 again in all the manifests. After `mvn install`:
```
$ git diff --name-only
net.ivoa.vodml.ide/META-INF/MANIFEST.MF
net.ivoa.vodml.tests/META-INF/MANIFEST.MF
net.ivoa.vodml.ui/META-INF/MANIFEST.MF
net.ivoa.vodml/META-INF/MANIFEST.MF
```
with many changes, one of them being
```
- org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
```

The next `mvn install` will fail with
```
[ERROR] Cannot resolve project dependencies:
[ERROR]   Software being installed: net.ivoa.vodsl 0.4.0.qualifier
[ERROR]   Missing requirement: net.ivoa.vodsl 0.4.0.qualifier requires 'osgi.bundle; org.eclipse.xtend.lib 2.14.0' but it could not be found
```


